### PR TITLE
Voronoi: Fix the bounds for randint

### DIFF
--- a/Voronoi.FCMacro
+++ b/Voronoi.FCMacro
@@ -228,7 +228,7 @@ class VoronoiForm(QDialog):
         self.show()
 
     def setnewseed(self):
-        self.seed.setText(str(np.random.randint(0, 2**32)))
+        self.seed.setText(str(np.random.randint(0, np.iinfo(np.int32).max)))
 
     @staticmethod
     def get_field_as(field, fun):


### PR DESCRIPTION
This commit fixes the upper bound for randint. 2**32 resulted in int32 overflow and the Random button didn't work at all.

> 14:27:32 self.seed.setText(str(np.random.randint(0, 2**32)))
> 14:27:32 File "mtrand.pyx", line 744, in numpy.random.mtrand.RandomState.randint
> 14:27:32 File "_bounded_integers.pyx", line 1343, in numpy.random._bounded_integers._rand_int32
> 14:27:32 ValueError: high is out of bounds for int32