### PR TITLE
Voronoi: Fix open polygons issue

### DIFF
--- a/Voronoi.FCMacro
+++ b/Voronoi.FCMacro
@@ -141,6 +141,90 @@ def fill_triangle(v0, v1, v2, n=100):
     x = np.array([p if point_in_triangle(p, v0, v01, v02) else mirror_point_at_point(p, s) for p in x])
     return x.T
 
+"""
+Function by @pv (Pauli Virtanen)
+https://gist.github.com/pv/8036995
+"""
+def voronoi_finite_polygons_2d(vor, radius=None):
+    """
+    Reconstruct infinite voronoi regions in a 2D diagram to finite
+    regions.
+    Parameters
+    ----------
+    vor : Voronoi
+        Input diagram
+    radius : float, optional
+        Distance to 'points at infinity'.
+    Returns
+    -------
+    regions : list of tuples
+        Indices of vertices in each revised Voronoi regions.
+    vertices : list of tuples
+        Coordinates for revised Voronoi vertices. Same as coordinates
+        of input vertices, with 'points at infinity' appended to the
+        end.
+    """
+
+    if vor.points.shape[1] != 2:
+        raise ValueError("Requires 2D input")
+
+    new_regions = []
+    new_vertices = vor.vertices.tolist()
+
+    center = vor.points.mean(axis=0)
+    if radius is None:
+        radius = vor.points.ptp().max()*2
+
+    # Construct a map containing all ridges for a given point
+    all_ridges = {}
+    for (p1, p2), (v1, v2) in zip(vor.ridge_points, vor.ridge_vertices):
+        all_ridges.setdefault(p1, []).append((p2, v1, v2))
+        all_ridges.setdefault(p2, []).append((p1, v1, v2))
+
+    # Reconstruct infinite regions
+    for p1, region in enumerate(vor.point_region):
+        vertices = vor.regions[region]
+
+        if all(v >= 0 for v in vertices):
+            # finite region
+            new_regions.append(vertices)
+            continue
+
+        # reconstruct a non-finite region
+        ridges = all_ridges[p1]
+        new_region = [v for v in vertices if v >= 0]
+
+        for p2, v1, v2 in ridges:
+            if v2 < 0:
+                v1, v2 = v2, v1
+            if v1 >= 0:
+                # finite ridge: already in the region
+                continue
+
+            # Compute the missing endpoint of an infinite ridge
+
+            t = vor.points[p2] - vor.points[p1] # tangent
+            t /= np.linalg.norm(t)
+            n = np.array([-t[1], t[0]])  # normal
+
+            midpoint = vor.points[[p1, p2]].mean(axis=0)
+            direction = np.sign(np.dot(midpoint - center, n)) * n
+            far_point = vor.vertices[v2] + direction * radius
+
+            new_region.append(len(new_vertices))
+            new_vertices.append(far_point.tolist())
+
+        # sort region counterclockwise
+        vs = np.asarray([new_vertices[v] for v in new_region])
+        c = vs.mean(axis=0)
+        angles = np.arctan2(vs[:,1] - c[1], vs[:,0] - c[0])
+        new_region = np.array(new_region)[np.argsort(angles)]
+
+        # finish
+        new_regions.append(new_region.tolist())
+        
+    return new_regions, np.asarray(new_vertices)
+
 
 def fill_voronoi_offset(sketch, points, origin_face, offset):
     """
@@ -157,25 +241,28 @@ def fill_voronoi_offset(sketch, points, origin_face, offset):
     :param Part.Face origin_face: Originating face in sketch coordinates
     :param float offset: the offset in Units to offset all lines. Positive offsets make the cells smaller
     """
-    v = Voronoi(points)
+    vor = Voronoi(points)
+    
+    regions, vertices = voronoi_finite_polygons_2d(vor)
 
     # Debug: show all points
     #for p in points:
     #    sketch.addGeometry(Part.Point(App.Vector(*p, 0)))
 
-    for r in v.regions:
+    for r in regions:
         # Simply remove points which are outside of the face...
-        while -1 in r:
-            r.remove(-1)
+        #while -1 in r:
+        #   r.remove(-1)
 
         if r == []:
             continue
 
         # Make a wire and calculate the offset
-        wire = Part.makePolygon([App.Vector(*v.vertices[x], 0) for x in r] + [App.Vector(*v.vertices[r[0]], 0)])
+        wire = Part.makePolygon([App.Vector(*vertices[x], 0) for x in r]+ [App.Vector(*vertices[r[0]], 0)])
         face = Part.makeFace(wire, 'Part::FaceMakerSimple')
 
         section = face.common(origin_face)
+
         # If the face has holes, there might be a different number of wires
         # than one...
         for new_wire in section.Wires:
@@ -320,7 +407,7 @@ def voronoi_on_face(n, offset, tol):
         msg('Error', 'Need an active body!')
         return
 
-    sketch = App.ActiveDocument.addObject('Sketcher::SketchObject', 'Vornoi_Sketch')
+    sketch = App.ActiveDocument.addObject('Sketcher::SketchObject', 'Voronoi_Sketch')
     body.addObject(sketch)
     sketch.MapMode = 'FlatFace'
     sketch.Support = (feature, face_name)
@@ -351,6 +438,7 @@ def voronoi_on_face(n, offset, tol):
     fill_voronoi_offset(sketch, points, face.transformed(transform), offset)
 
     App.ActiveDocument.recompute()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes the issue of open polygons in the corners of the plane - the Voronoi pattern wasn't finished there.
The function used to close the polygons is `voronoi_finite_polygons_2d` by @pv as in https://gist.github.com/pv/8036995.
Still needs some fixing for circular holes in the plane. Apparently the rectangular holes are not affected.

Before fixing:
![bef](https://user-images.githubusercontent.com/2939266/154720893-f61cd9ec-c1dc-46ef-a26f-ee95953e044a.PNG)

After fixing:
![aft](https://user-images.githubusercontent.com/2939266/154720947-0aed6830-2665-4bd6-8155-4d68be1363f3.PNG)

Issue with circular holes:
![holes2](https://user-images.githubusercontent.com/2939266/154724031-f8e7b38d-a48e-412c-bd6e-86c6f842a37d.PNG)

