### PR TITLE
Update the calls to be compatible with NumPy 2.0

### DIFF
--- a/Voronoi.FCMacro
+++ b/Voronoi.FCMacro
@@ -173,7 +173,10 @@ def voronoi_finite_polygons_2d(vor, radius=None):
 
     center = vor.points.mean(axis=0)
     if radius is None:
-        radius = vor.points.ptp().max()*2
+        if np.__version__.startswith('2.'):
+            radius = np.ptp(vor.points).max()*2
+        else:
+            radius = vor.points.ptp().max()*2
 
     # Construct a map containing all ridges for a given point
     all_ridges = {}
@@ -222,7 +225,7 @@ def voronoi_finite_polygons_2d(vor, radius=None):
 
         # finish
         new_regions.append(new_region.tolist())
-        
+
     return new_regions, np.asarray(new_vertices)
 
 
@@ -242,7 +245,7 @@ def fill_voronoi_offset(sketch, points, origin_face, offset):
     :param float offset: the offset in Units to offset all lines. Positive offsets make the cells smaller
     """
     vor = Voronoi(points)
-    
+
     regions, vertices = voronoi_finite_polygons_2d(vor)
 
     # Debug: show all points


### PR DESCRIPTION
With the release of NumPy 2.0, the `ptp` method was removed, with a
replacement being `np.ptp`.

See also: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ndarray-and-scalar-methods

Signed-off-by: Milan Plzik <milan.plzik@gmail.com>
